### PR TITLE
Add usage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ or you can include the following in your composer.json file:
 Notice that tFPDF is not name-spaced. You can extend the class this way:
 
 ```php 
-    class \your\namespace\Document extends \tFPDF
+    namespace your\namespace;
+    
+    class Document extends \tFPDF
 ```
 
 or create an instance this way:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ or you can include the following in your composer.json file:
 Notice that tFPDF is not name-spaced. You can extend the class this way:
 
 ```php 
-    class Document extends \tFPDF
+    class \your\namespace\Document extends \tFPDF
 ```
 
 or create an instance this way:

--- a/README.md
+++ b/README.md
@@ -36,3 +36,18 @@ or you can include the following in your composer.json file:
     }
 }
 ```
+
+## Usage
+
+The alias is `\tFPDF`. You may extend the class by
+
+```php 
+    class Document extends \tFPDF
+```
+
+or create a new one like this:
+
+
+```php 
+    $pdf = new \tFPDF();
+```

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ or you can include the following in your composer.json file:
 
 ## Usage
 
-The alias is `\tFPDF`. You may extend the class by
+Notice that tFPDF is not name-spaced. You can extend the class this way:
 
 ```php 
     class Document extends \tFPDF
 ```
 
-or create a new one like this:
+or create an instance this way:
 
 
 ```php 


### PR DESCRIPTION
It wasn't mentioned anywhere what the namespace of the class is. I had to go to the vendor and find out its loaded by classmap. I think it should be mentioned in the readme how to access the class.